### PR TITLE
fix(launcher): keep first result selected while typing

### DIFF
--- a/src/app_impl/filter_input_updates.rs
+++ b/src/app_impl/filter_input_updates.rs
@@ -163,11 +163,6 @@ impl ScriptListApp {
         }
         if self.computed_filter_text != value {
             let update_start = std::time::Instant::now();
-            let selection_before = if matches!(self.current_view, AppView::ScriptList) {
-                Some(self.main_menu_selection_snapshot())
-            } else {
-                None
-            };
             self.filter_coalescer.reset();
             self.computed_filter_text = value.clone();
             if crate::menu_syntax::active_filter_head_owns_main_list(&value) {
@@ -181,11 +176,6 @@ impl ScriptListApp {
             self.maybe_start_root_browser_tabs_refresh_for_query(&value, cx);
             self.maybe_start_root_browser_history_refresh_for_query(&value, cx);
             self.reconcile_script_list_after_filter_change("filter_immediate", cx);
-            if let Some(snapshot) = selection_before.as_ref() {
-                if self.restore_root_file_handoff_selection_from_snapshot(snapshot) {
-                    self.scroll_to_selected_if_needed("filter_immediate_restore_root_file_handoff");
-                }
-            }
             self.rebuild_main_window_preflight_if_needed();
             if self.filter_change_can_affect_window_size() {
                 self.update_window_size();
@@ -1341,7 +1331,7 @@ impl ScriptListApp {
 
 #[cfg(test)]
 mod tests {
-    use super::menu_syntax_filter_only_escape_should_clear;
+    use super::{menu_syntax_filter_only_escape_should_clear, *};
 
     fn should_clear(raw: &str) -> bool {
         let mode = crate::menu_syntax::MenuSyntaxMode::from_input(raw);
@@ -1369,6 +1359,52 @@ mod tests {
         assert!(!should_clear("type:script git"));
         assert!(!should_clear("plain search"));
         assert!(!should_clear(""));
+    }
+
+    #[gpui::test]
+    fn query_change_discards_root_file_handoff_selection(cx: &mut gpui::TestAppContext) {
+        let app = main_menu_selection_test_app(cx);
+        app.update(cx, |app, cx| {
+            let old_query = "zzlauncherhandoffprobe";
+            let new_query = "zzlauncherhandoffprobe reset";
+            let handoff_key = "fallback/root-file-search-handoff/global";
+
+            app.scripts = vec![main_menu_selection_test_script(
+                "zzlauncherhandoffprobe reset first",
+            )];
+            app.scriptlets.clear();
+            app.skills.clear();
+            app.apps.clear();
+            app.computed_filter_text = old_query.to_string();
+            app.filter_text = old_query.to_string();
+            app.menu_syntax_mode = crate::menu_syntax::MenuSyntaxMode::from_input(old_query);
+            app.root_file_search_mode =
+                Some(crate::file_search::RootFileSectionMode::GlobalQuery);
+            app.root_file_search_query = old_query.to_string();
+            app.root_file_search_loading = true;
+            app.root_file_provider_loading = true;
+            app.invalidate_grouped_cache();
+            app.get_grouped_results_cached();
+
+            app.selected_index = app
+                .main_menu_result_caches
+                .grouped_index_for_stable_selection_key(handoff_key)
+                .expect("old query should include the Search Files handoff");
+
+            app.filter_text = new_query.to_string();
+            app.menu_syntax_mode = crate::menu_syntax::MenuSyntaxMode::from_input(new_query);
+            app.apply_filter_compute_now(new_query.to_string(), cx);
+
+            let selected_key = selected_main_menu_stable_key(app);
+            let first_key = first_selectable_main_menu_stable_key(app);
+            assert_eq!(app.computed_filter_text, new_query);
+            assert_eq!(selected_key, first_key);
+            assert_ne!(selected_key.as_deref(), Some(handoff_key));
+            assert!(app
+                .main_menu_result_caches
+                .search_result_for_grouped_item(app.selected_index)
+                .is_some());
+        });
     }
 }
 

--- a/src/app_impl/root_file_search.rs
+++ b/src/app_impl/root_file_search.rs
@@ -517,6 +517,63 @@ fn root_file_result_fingerprint(files: &[crate::file_search::FileResult]) -> Vec
     files.iter().map(|file| file.path.as_str()).collect()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[gpui::test]
+    fn same_query_root_file_publish_preserves_selected_identity(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let app = main_menu_selection_test_app(cx);
+        app.update(cx, |app, cx| {
+            let query = "zzlauncherrefreshprobe";
+            let handoff_key = "fallback/root-file-search-handoff/global";
+            app.scripts = vec![main_menu_selection_test_script(
+                "zzlauncherrefreshprobe first",
+            )];
+            app.scriptlets.clear();
+            app.skills.clear();
+            app.apps.clear();
+            app.computed_filter_text = query.to_string();
+            app.filter_text = query.to_string();
+            app.menu_syntax_mode = crate::menu_syntax::MenuSyntaxMode::from_input(query);
+            app.root_file_search_generation = 41;
+            app.root_file_search_mode =
+                Some(crate::file_search::RootFileSectionMode::GlobalQuery);
+            app.root_file_search_query = query.to_string();
+            app.root_file_search_loading = true;
+            app.root_file_provider_loading = true;
+            app.invalidate_grouped_cache();
+            app.get_grouped_results_cached();
+            app.selected_index = app
+                .main_menu_result_caches
+                .grouped_index_for_stable_selection_key(handoff_key)
+                .expect("same query should include the Search Files handoff");
+            let selected_before = selected_main_menu_stable_key(app);
+
+            app.apply_root_file_search_results_for_generation(
+                41,
+                vec![crate::file_search::FileResult {
+                    path: "/tmp/zzlauncherrefreshprobe.txt".to_string(),
+                    name: "zzlauncherrefreshprobe.txt".to_string(),
+                    size: 1,
+                    modified: 1,
+                    file_type: crate::file_search::FileType::File,
+                }],
+                false,
+                true,
+                cx,
+            );
+
+            let selected_after = selected_main_menu_stable_key(app);
+            assert_eq!(selected_before.as_deref(), Some(handoff_key));
+            assert_eq!(selected_after, selected_before);
+            assert_ne!(selected_after, first_selectable_main_menu_stable_key(app));
+        });
+    }
+}
+
 fn dedupe_root_file_results(
     results: Vec<crate::file_search::FileResult>,
 ) -> Vec<crate::file_search::FileResult> {

--- a/src/main_sections/app_state.rs
+++ b/src/main_sections/app_state.rs
@@ -494,14 +494,6 @@ pub(crate) struct MainMenuSelectionSnapshot {
     selected_key: Option<String>,
 }
 
-impl MainMenuSelectionSnapshot {
-    fn is_root_file_handoff_selection(&self) -> bool {
-        self.selected_key
-            .as_deref()
-            .is_some_and(|key| key.starts_with("fallback/root-file-search-handoff/"))
-    }
-}
-
 impl ScriptListApp {
     pub(crate) fn root_file_source_chip_page_key_for(
         raw_filter_text: &str,
@@ -584,34 +576,79 @@ impl ScriptListApp {
         true
     }
 
-    pub(crate) fn restore_root_file_handoff_selection_from_snapshot(
+}
+
+#[cfg(test)]
+struct MainMenuSelectionTestHost;
+
+#[cfg(test)]
+impl gpui::Render for MainMenuSelectionTestHost {
+    fn render(
         &mut self,
-        snapshot: &MainMenuSelectionSnapshot,
-    ) -> bool {
-        if !snapshot.is_root_file_handoff_selection() {
-            return false;
-        }
-        let Some(selected_key) = snapshot.selected_key.as_deref() else {
-            return false;
-        };
-
-        self.get_grouped_results_cached();
-        let Some(grouped_index) = self
-            .main_menu_result_caches
-            .grouped_index_for_stable_selection_key(selected_key)
-        else {
-            return false;
-        };
-
-        if self.selected_index == grouped_index {
-            return false;
-        }
-
-        self.selected_index = grouped_index;
-        self.hovered_index = None;
-        self.last_scrolled_index = None;
-        true
+        _window: &mut gpui::Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> impl gpui::IntoElement {
+        gpui::div()
     }
+}
+
+#[cfg(test)]
+fn main_menu_selection_test_app(
+    cx: &mut gpui::TestAppContext,
+) -> gpui::Entity<ScriptListApp> {
+    use gpui::AppContext as _;
+
+    let app = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let app_for_window = app.clone();
+    cx.update(|cx| {
+        gpui_component::init(cx);
+        cx.open_window(Default::default(), |window, cx| {
+            let entity = cx.new(|cx| {
+                ScriptListApp::new(crate::config::Config::default(), false, window, cx)
+            });
+            *app_for_window.lock().expect("lock selection test app") = Some(entity);
+            cx.new(|_| MainMenuSelectionTestHost)
+        })
+        .expect("open main-menu selection test window");
+    });
+    let entity = app
+        .lock()
+        .expect("lock initialized selection test app")
+        .take()
+        .expect("selection test app initialized");
+    entity
+}
+
+#[cfg(test)]
+fn main_menu_selection_test_script(name: &str) -> std::sync::Arc<crate::scripts::Script> {
+    std::sync::Arc::new(crate::scripts::Script {
+        name: name.to_string(),
+        path: std::path::PathBuf::from(format!("/tmp/{name}.ts")),
+        extension: "ts".to_string(),
+        plugin_id: "main".to_string(),
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+fn selected_main_menu_stable_key(app: &mut ScriptListApp) -> Option<String> {
+    app.get_grouped_results_cached();
+    app.main_menu_result_caches
+        .flat_result_index_for_coerced_grouped_selection(app.selected_index)
+        .and_then(|(_, result_index)| {
+            app.main_menu_result_caches
+                .search_result_for_flat_index(result_index)
+        })
+        .and_then(crate::scripts::SearchResult::stable_selection_key)
+}
+
+#[cfg(test)]
+fn first_selectable_main_menu_stable_key(app: &mut ScriptListApp) -> Option<String> {
+    app.get_grouped_results_cached();
+    let first = app.main_menu_result_caches.first_selectable_index()?;
+    app.main_menu_result_caches
+        .search_result_for_grouped_item(first)
+        .and_then(crate::scripts::SearchResult::stable_selection_key)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tests/filter_input_updates_reconciliation.rs
+++ b/tests/filter_input_updates_reconciliation.rs
@@ -78,33 +78,6 @@ fn reconcile_helper_calls_scroll_to_selected_if_needed() {
 }
 
 #[test]
-fn reconcile_helper_selects_first_selectable_before_list_replacement() {
-    let source = read_source();
-    let section = function_body(&source, "fn reconcile_script_list_after_filter_change");
-
-    let first_selectable = section
-        .find("first_selectable_index()")
-        .expect("reconciliation must choose the first selectable row");
-    let sync = section
-        .find("self.sync_list_state_for_filter_replacement();")
-        .expect("reconciliation must sync the GPUI list state");
-    let validate = section
-        .find("self.validate_selection_bounds(cx);")
-        .expect("reconciliation must validate after list sync");
-
-    assert!(
-        first_selectable < sync && sync < validate,
-        "filter reconciliation must choose first selectable before replacing list state, then validate"
-    );
-
-    let sync_to_validate = &section[sync..validate];
-    assert!(
-        !sync_to_validate.contains("self.selected_index = 0;"),
-        "filter reconciliation must not expose raw row 0 between list replacement and validation"
-    );
-}
-
-#[test]
 fn reconcile_helper_calls_rebuild_preflight() {
     let source = read_source();
     let section = slice_from(

--- a/tests/filter_list_state_replacement_contract.rs
+++ b/tests/filter_list_state_replacement_contract.rs
@@ -87,15 +87,4 @@ fn script_list_filter_reconciliation_still_validates_and_reveals() {
             "script-list filter reconciliation must keep `{needle}` after list-state sync"
         );
     }
-
-    let select_ix = reconcile_body
-        .find("first_selectable_index()")
-        .expect("script-list filter reconciliation must select the first selectable row");
-    let sync_ix = reconcile_body
-        .find("self.sync_list_state_for_filter_replacement();")
-        .expect("script-list filter reconciliation must sync list state");
-    assert!(
-        select_ix < sync_ix,
-        "script-list filter reconciliation must select the first selectable row before list-state replacement"
-    );
 }


### PR DESCRIPTION
## Summary

- remove the query-unsafe restoration that could reselect the root `Search Files` handoff after a main-menu query changed
- keep same-query asynchronous provider refreshes able to preserve an explicitly moved selection
- add GPUI behavior coverage for both changed-query reset and same-query refresh, replacing stale source-shape assertions

## Verification

- `./scripts/agentic/agent-cargo.sh test --bin script-kit-gpui query_change_discards_root_file_handoff_selection -- --nocapture`
- `./scripts/agentic/agent-cargo.sh test --bin script-kit-gpui same_query_root_file_publish_preserves_selected_identity -- --nocapture`
- `./scripts/agentic/agent-cargo.sh test --test filter_input_updates_reconciliation --quiet`
- `./scripts/agentic/agent-cargo.sh test --test filter_list_state_replacement_contract --quiet`
- `./scripts/agentic/agent-cargo.sh check --bin script-kit-gpui`
- pre-push `cargo fmt --check` and `cargo check`
- real GPUI DevTools proof: selected `Search Files for "This i"`, dispatched printable `s`, and observed `This is` with `script/main:This Is Beta` both selected and first; `input:filter` retained focus; selected row remained visible and above the footer; cleanup ended with `windowVisible:false`

## Oracle

- `launcher-selection-reset-fix`
